### PR TITLE
Updaed pipelines to remove deprecations error

### DIFF
--- a/config/pipeline.php
+++ b/config/pipeline.php
@@ -7,8 +7,8 @@
 $app->pipe(\Zend\Stratigility\Middleware\OriginalMessages::class);
 $app->pipe(\Zend\Stratigility\Middleware\ErrorHandler::class);
 $app->pipe(\Zend\Expressive\Helper\ServerUrlMiddleware::class);
-$app->pipeRoutingMiddleware();
+$app->pipe(\Zend\Expressive\Router\Middleware\RouteMiddleware::class);
 $app->pipe(\Zend\Expressive\Middleware\ImplicitHeadMiddleware::class);
 $app->pipe(\Zend\Expressive\Middleware\ImplicitOptionsMiddleware::class);
-$app->pipeDispatchMiddleware();
+$app->pipe(\Zend\Expressive\Router\Middleware\DispatchMiddleware::class);
 $app->pipe(\Zend\Expressive\Middleware\NotFoundHandler::class);


### PR DESCRIPTION
I hope this should fix our Travis builds: 

https://travis-ci.org/Codeception/Codeception/jobs/352600644#L3979

Current errors:

---

Deprecated: Usage of the Zend\Expressive\Application::ROUTING_MIDDLEWARE constant for specifying routing middleware is deprecated; pipe() the middleware directly, or reference it by its service name "Zend\Expressive\Router\Middleware\RouteMiddleware"

PHP Deprecated:  Usage of the Zend\Expressive\Application::DISPATCH_MIDDLEWARE constant for specifying dispatch middleware is deprecated; pipe() the middleware directly, or reference it by its service name "Zend\Expressive\Router\Middleware\DispatchMiddleware" in /home/travis/build/Codeception/Codeception/frameworks-zend-expressive/vendor/zendframework/zend-expressive/src/MarshalMiddlewareTrait.php on line 205